### PR TITLE
update the trip service for token authentication with pod identity

### DIFF
--- a/src/trips/README.md
+++ b/src/trips/README.md
@@ -56,7 +56,8 @@ The value for a configuration variable may be specified via an environment varia
 | SQL_PASSWORD         | Yes      | ENV or File |               | The password for the SQL Server database.     |
 | SQL_SERVER           | Yes      | ENV or File |               | The server name for the SQL Server database.  |
 | SQL_DBNAME           | Yes      | ENV or File | mydrivingDB   | The name of the SQL Server database.          |
-| CREDENTIAL_METHOD           | No      | ENV or File | username_and_password   | Explicit credential process to access SQL DB. options: `username_and_password` or `token`       |
+| CREDENTIAL_METHOD           | No      | ENV | username_and_password   | Explicit credential process to access SQL DB. options: `username_and_password` or `managed_identity`       |
+| IDENTITY_CLIENT_ID           | No      | ENV |    | The Client ID for a user-assigned identity to an azure resource,required for `managed_identity` credential process to access SQL DB |
 | OPENAPI_DOCS_URI     | Yes      | ENV         |               | The external ip address and port of this api. This is used by the OpenAPI UI. |
 | DEBUG_LOGGING        | No       | ENV         | false         | Add debug logging.                            |
 
@@ -170,5 +171,5 @@ curl -i -X DELETE 'http://localhost:8080/api/trips/ea2f7ae0-3cef-49cb-b7d1-ce972
 Get healthcheck status
 
 ```bash
-curl -i -X GET 'http://localhost:8080/api/trips/healthcheck' 
+curl -i -X GET 'http://localhost:8080/api/trips/healthcheck'
 ```

--- a/src/trips/README.md
+++ b/src/trips/README.md
@@ -56,6 +56,7 @@ The value for a configuration variable may be specified via an environment varia
 | SQL_PASSWORD         | Yes      | ENV or File |               | The password for the SQL Server database.     |
 | SQL_SERVER           | Yes      | ENV or File |               | The server name for the SQL Server database.  |
 | SQL_DBNAME           | Yes      | ENV or File | mydrivingDB   | The name of the SQL Server database.          |
+| CREDENTIAL_METHOD           | No      | ENV or File | username_and_password   | Explicit credential process to access SQL DB. options: `username_and_password` or `token`       |
 | OPENAPI_DOCS_URI     | Yes      | ENV         |               | The external ip address and port of this api. This is used by the OpenAPI UI. |
 | DEBUG_LOGGING        | No       | ENV         | false         | Add debug logging.                            |
 

--- a/src/trips/go.mod
+++ b/src/trips/go.mod
@@ -1,13 +1,32 @@
 module app
 
+go 1.17
+
 require (
-	cloud.google.com/go v0.0.0-20180627205256-45528feae6df // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.15
 	github.com/codemodus/swagui v0.1.0
-	github.com/denisenkom/go-mssqldb v0.0.0-20180625034930-3724b4745ca9
+	github.com/denisenkom/go-mssqldb v0.10.0
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/stretchr/testify v1.3.0
+)
+
+require (
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.1 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang-jwt/jwt/v4 v4.0.0 // indirect
+	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
+	github.com/prometheus/common v0.6.0 // indirect
+	github.com/prometheus/procfs v0.0.3 // indirect
+	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
+	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 // indirect
 )

--- a/src/trips/tripsgo/dataAccess.go
+++ b/src/trips/tripsgo/dataAccess.go
@@ -8,6 +8,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/Azure/go-autorest/autorest/adal"
+	mssql "github.com/denisenkom/go-mssqldb"
+	// "github.com/Azure/go-autorest/autorest/azure/auth"
 )
 
 func getEnv(key, fallback string) string {
@@ -45,26 +49,74 @@ func getConfigValue(name string, fallback string) string {
 var (
 	debug    = flag.Bool("debug", false, "enable debugging")
 	password = flag.String("password", getConfigValue("SQL_PASSWORD", "changeme"), "the database password")
+	user     = flag.String("user", getConfigValue("SQL_USER", "sqladmin"), "the database user")
 	port     = flag.Int("port", 1433, "the database port")
 	server   = flag.String("server", getConfigValue("SQL_SERVER", "changeme.database.windows.net"), "the database server")
-	user     = flag.String("user", getConfigValue("SQL_USER", "sqladmin"), "the database user")
 	database = flag.String("d", getConfigValue("SQL_DBNAME", "mydrivingDB"), "db_name")
+	// credential_method = flag.String("c", getConfigValue("CREDENTIAL_METHOD", "username_and_password"), "credential method") // username_and_password vs token (Be more explicit about it)
 )
+
+func getTokenProvider() (func() (string, error), error) {
+	msiEndpoint, err := adal.GetMSIEndpoint()
+	if err != nil {
+		return nil, err
+	}
+	// scoped to the database.windows.net
+	msi, err := adal.NewServicePrincipalTokenFromMSI(
+		msiEndpoint, "https://database.windows.net/")
+	if err != nil {
+		return nil, err
+	}
+
+	return func() (string, error) {
+		msi.EnsureFresh()
+		token := msi.OAuthToken()
+		return token, nil
+	}, nil
+}
+
+func getDBConnection() (*sql.DB, error) {
+	var conn *sql.DB
+	credential_method := getConfigValue("CREDENTIAL_METHOD", "username_and_password") // not utilized elsewhere.
+	switch credential_method {
+
+	case "token":
+		connectionString := fmt.Sprintf("Server=%s;Database=%s", *server, *database)
+
+		tokenProvider, err := getTokenProvider()
+		if err != nil {
+			logError(err, "Error creating token provider for system assigned Azure Managed Identity:")
+		}
+
+		accessTokenConnection, err := mssql.NewAccessTokenConnector(connectionString, tokenProvider)
+		if err != nil {
+			logError(err, "Error establishing DB connection using a token")
+			return nil, err
+		}
+		conn = sql.OpenDB(accessTokenConnection)
+
+	case "username_and_password":
+		connectionString := fmt.Sprintf("server=%s;database=%s;user id=%s;password=%s;port=%d", *server, *database, *user, *password, *port)
+
+		if *debug {
+			fmt.Printf("connString:%s\n", connectionString)
+		}
+		usernameAndPasswordConnection, err := sql.Open("mssql", connectionString)
+		if err != nil {
+			logError(err, "Error creating MSSQL Connection using UserName and Password")
+			return nil, err
+		}
+		conn = usernameAndPasswordConnection
+	}
+	return conn, nil
+}
 
 // ExecuteNonQuery - Execute a SQL query that has no records returned (Ex. Delete)
 func ExecuteNonQuery(query string) (string, error) {
-	connString := fmt.Sprintf("server=%s;database=%s;user id=%s;password=%s;port=%d", *server, *database, *user, *password, *port)
-
-	if *debug {
-		fmt.Printf("connString:%s\n", connString)
-	}
-
-	conn, err := sql.Open("mssql", connString)
-
+	conn, err := getDBConnection()
 	if err != nil {
 		return "", err
 	}
-
 	defer conn.Close()
 
 	statement, err := conn.Prepare(query)
@@ -88,18 +140,10 @@ func ExecuteNonQuery(query string) (string, error) {
 
 // ExecuteQuery - Executes a query and returns the result set
 func ExecuteQuery(query string) (*sql.Rows, error) {
-	connString := fmt.Sprintf("server=%s;database=%s;user id=%s;password=%s;port=%d", *server, *database, *user, *password, *port)
-
-	// Debug.Println("connString:%s\n", connString)
-
-	conn, err := sql.Open("mssql", connString)
-
+	conn, err := getDBConnection()
 	if err != nil {
-		logError(err, "Failed to connect to database.")
 		return nil, err
-
 	}
-
 	defer conn.Close()
 
 	statement, err := conn.Prepare(query)


### PR DESCRIPTION
modified [trip service](https://github.com/Microsoft-OpenHack/containers_artifacts/tree/main/src/trips) to accept a new `env` variable `CREDENTIAL_METHOD`  requiring attendees to be explicit about the credential process utilized to access SQL DB. 
Options: `username_and_password` or `token`
- `username_and_password` is the default option, this uses the secret based approach to authenticate. 
- ~~`token`~~ `managed_identity` is intended for managed identity approach of authentication.