### PR TITLE
Fix or Workaround when testing POI with Sql Server

### DIFF
--- a/src/poi/web/appsettings.Development.json
+++ b/src/poi/web/appsettings.Development.json
@@ -1,6 +1,6 @@
 ﻿{
   "ConnectionStrings": {
-    "myDrivingDB": "Server=tcp:[SQL_SERVER],1433;Initial Catalog=[SQL_DBNAME];Persist Security Info=False;User ID=[SQL_USER];Password=[SQL_PASSWORD];MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "myDrivingDB": "Server=tcp:[SQL_SERVER],1433;Initial Catalog=[SQL_DBNAME];Persist Security Info=False;User ID=[SQL_USER];Password=[SQL_PASSWORD];MultipleActiveResultSets=False;Encrypt=False;TrustServerCertificate=True;Connection Timeout=30;"
   },
   "Logging": {
     "IncludeScopes": false,


### PR DESCRIPTION
Fix or Workaround when testing POI with Sql Server on local enviroment using docker. Without these settings the connection to Sql Server container will fail because the server certificate can not be validated. This does not happens with Azure Sql for obvious reasons.